### PR TITLE
Add another online judge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 * [CareerCup](https://www.careercup.com/)
 * [HackerRank](https://www.hackerrank.com/)
 * [CodeFights](https://codefights.com/)
+* [Kattis](https://open.kattis.com/)
 
 ## Live Coding Practice
 * [Gainlo](http://www.gainlo.co/#!/)


### PR DESCRIPTION
Kattis is another online judge that's somewhat similar to HackerRank, but filled with problems from ACM-ICPC and other programming contests.