### PR TITLE
Add Lobsters to the CS news section

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ or equal to those of the children and the lowest key is in the root node
 
 ## Computer Science News
 * [Hacker News](https://news.ycombinator.com/)
+* [Lobsters](https://lobste.rs/)
 
 ## Directory Tree
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ or equal to those of the children and the lowest key is in the root node
 
 ![Alt text](/Images/kruskal.gif?raw=true "Kruskal's Algorithm")
 
-##Bitmasks
+## Bitmasks
 * Bitmasking is a technique used to perform operations at the bit level. Leveraging bitmasks often leads to faster runtime complexity and
   helps limit memory usage
 * Test kth bit: `s & (1 << k);`


### PR DESCRIPTION
Lobsters is a link aggregation site similar to HN, but usually just has a different mix of tech news.

Also there was a missing space at the "Bitmasks" heading.