### PR TITLE
Change CodeFights to CodeSignal

### DIFF
--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -30,7 +30,7 @@
 * [Virtual Judge](https://vjudge.net/)
 * [CareerCup](https://www.careercup.com/)
 * [HackerRank](https://www.hackerrank.com/)
-* [CodeFights](https://codefights.com/)
+* [CodeSignal](https://codesignal.com/)
 * [Kattis](https://open.kattis.com/)
 * [HackerEarth](https://www.hackerearth.com)
 * [Codility](https://codility.com/programmers/lessons/1-iterations/)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 * [Virtual Judge](https://vjudge.net/)
 * [CareerCup](https://www.careercup.com/)
 * [HackerRank](https://www.hackerrank.com/)
-* [CodeFights](https://codefights.com/)
+* [CodeSignal](https://codesignal.com/)
 * [Kattis](https://open.kattis.com/)
 * [HackerEarth](https://www.hackerearth.com)
 * [Codility](https://codility.com/programmers/lessons/1-iterations/)


### PR DESCRIPTION
CodeFights recently changed their name to CodeSignal. Updating README.md to reflect this.