### PR TITLE
Include diff.blog in Compter Science News section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ or equal to those of the children and the lowest key is in the root node
 ## Computer Science News
 * [Hacker News](https://news.ycombinator.com/)
 * [Lobsters](https://lobste.rs/)
+* [diff.blog](https://diff.blog/)
 
 ## Directory Tree
 


### PR DESCRIPTION
https://diff.blog is an aggregator of computer science engineering and developer blogs. I built it around 1.5 years back and I plan to keep it running as much as I can.

Links to a recent [HN discussion](https://news.ycombinator.com/item?id=23914454), [Product Hunt launch](https://www.producthunt.com/posts/diff-blog-2) and [an article](https://towardsdatascience.com/learning-from-the-giants-top-engineering-blogs-you-must-follow-fa8a0dd63f18) mentioning diff.blog in Towards Data Science to make it easier for you to review this :)